### PR TITLE
Compatibility with text-2.0

### DIFF
--- a/css-syntax.cabal
+++ b/css-syntax.cabal
@@ -33,7 +33,7 @@ library
   build-depends:
      base >=4 && <5
    , scientific
-   , text
+   , text >=2.0 && <2.1
 
   ghc-options: -Wall -O2
 


### PR DESCRIPTION
Hi, it's me again ;)

`text-2.0` uses UTF-8 as internal representation instead of UTF-16 used by previous versions. This PR makes `haskell-css-syntax` work with `text-2.0`.

All tests pass. Tokenization performance hadn't changed much, and serialization became a bit faster (fewer bytes to write).